### PR TITLE
fix issue in media library

### DIFF
--- a/ajax-thumbnail-rebuild.php
+++ b/ajax-thumbnail-rebuild.php
@@ -43,7 +43,6 @@ class AjaxThumbnailRebuild {
 	 * @return array
 	 */
 	function addRebuildSingle($fields, $post) {
-		global $post;
 		$thumbnails = array();
 		foreach ( ajax_thumbnail_rebuild_get_sizes() as $s )
 			$thumbnails[] = 'thumbnails[]='.$s['name'];


### PR DESCRIPTION
As I could not set post thumbnail anymore, I looked at the WP_DEBUG_LOG file, which stated:
`[15-Apr-2014 10:30:04 UTC] PHP Notice:  Trying to get property of non-object in /var/www/work/imatra/wp-content/plugins/ajax-thumbnail-rebuild/ajax-thumbnail-rebuild.php on line 66`

Fix was quite simple. You are using `global $post`, but it is not necessary, as the filter passes $post to your function as second parameter.
