### PR TITLE
apply filter on $sizes earlier

### DIFF
--- a/ajax-thumbnail-rebuild.php
+++ b/ajax-thumbnail-rebuild.php
@@ -291,7 +291,8 @@ function ajax_thumbnail_rebuild_get_sizes() {
 		else
 			$sizes[$s]['crop'] = get_option( "{$s}_crop" );
 	}
-
+	
+	$sizes = apply_filters( 'intermediate_image_sizes_advanced', $sizes );
 	return $sizes;
 }
 
@@ -319,7 +320,6 @@ function wp_generate_attachment_metadata_custom( $attachment_id, $file, $thumbna
 		$metadata['file'] = _wp_relative_upload_path($file);
 
 		$sizes = ajax_thumbnail_rebuild_get_sizes();
-		$sizes = apply_filters( 'intermediate_image_sizes_advanced', $sizes );
 
 		foreach ($sizes as $size => $size_data ) {
 			if( isset( $thumbnails ) && !in_array( $size, $thumbnails ))


### PR DESCRIPTION
Hooking *intermediate_image_sizes_advanced* directly in `ajax_thumbnail_rebuild_get_sizes()` makes the management page's list display consistent info (see L.178) in respect to what is processed by `wp_generate_attachment_metadata_custom()` – where the filter is currently applied.

My use case: I needed to hook *intermediate_image_sizes_advanced* to remove Wordpress' default image sizes as in [this example](http://www.paulund.co.uk/remove-default-wordpress-image-sizes). Before, in the plugin's management page, default image sizes were still shown in the list although not rebuilt.